### PR TITLE
Fix MP4 creation for older ffmpeg versions

### DIFF
--- a/generate_audio.sh
+++ b/generate_audio.sh
@@ -8,7 +8,7 @@ for k in $(seq -f "%02g" 1 10 151); do
     mkdir $DIR/$k
     for i in $(seq 1 $NBFILES); do
         sox -n -r 44100 $DIR/$k/$i.wav synth "0:$k" whitenoise vol 0.5 fade q 1 "0:$k" 1
-        ffmpeg -i $DIR/$k/$i.wav $DIR/$k/$i.mp4
+        ffmpeg -i $DIR/$k/$i.wav -strict -2 $DIR/$k/$i.mp4
         ffmpeg -i $DIR/$k/$i.wav $DIR/$k/$i.mp3
         ffmpeg -i $DIR/$k/$i.wav $DIR/$k/$i.flac
         ffmpeg -i $DIR/$k/$i.wav $DIR/$k/$i.ogg


### PR DESCRIPTION
This makes the script work for ffmpeg 2.8.15-0ubuntu0.16.04.1, so basically for Ubuntu 16.04.

I'm not able to test if it will work with newer versions as well. So please test before merging.